### PR TITLE
Added quotes around jinja variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for oh-my-zsh
 
-  - apt: name={{ item }} state=latest
+  - apt: name="{{ item }}" state=latest
     when: ansible_pkg_mgr == 'apt'
     sudo: true
     with_items:
@@ -9,7 +9,7 @@
       - git
     notify: clean apt cache
 
-  - yum: name={{ item }} state=latest
+  - yum: name="{{ item }}" state=latest
     when: ansible_pkg_mgr == 'yum'
     sudo: true
     with_items:
@@ -19,11 +19,11 @@
 
   - git: repo=git://github.com/robbyrussell/oh-my-zsh.git dest=~/.oh-my-zsh accept_hostkey=true update=no
     sudo: true
-    sudo_user: {{ ohmyzsh.user }}
+    sudo_user: "{{ ohmyzsh.user }}"
 
   - template: src=.zshrc.j2 dest=~/.zshrc backup=yes
     sudo: true
-    sudo_user: {{ ohmyzsh.user }}
+    sudo_user: "{{ ohmyzsh.user }}"
 
-  - user: name={{ ohmyzsh.user }} shell=/bin/zsh
+  - user: name="{{ ohmyzsh.user }}" shell=/bin/zsh
     sudo: true


### PR DESCRIPTION
Ansible 1.8.4 is moaning about syntax errors:

```
ERROR: Syntax Error while loading YAML script, /etc/ansible/roles/mashimom.oh-my-zsh/tasks/main.yml
Note: The error may actually appear before this position: line 22, column 17

    sudo: true
    sudo_user: {{ ohmyzsh.user }}
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mashimom/ohmyzsh_plbk/1)

<!-- Reviewable:end -->
