### PR TITLE
quote sudo user variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,11 +19,11 @@
 
   - git: repo=git://github.com/robbyrussell/oh-my-zsh.git dest=~/.oh-my-zsh accept_hostkey=true update=no
     sudo: true
-    sudo_user: {{ ohmyzsh.user }}
+    sudo_user: "{{ ohmyzsh.user }}"
 
   - template: src=.zshrc.j2 dest=~/.zshrc backup=yes
     sudo: true
-    sudo_user: {{ ohmyzsh.user }}
+    sudo_user: "{{ ohmyzsh.user }}"
 
   - user: name={{ ohmyzsh.user }} shell=/bin/zsh
     sudo: true


### PR DESCRIPTION
I've received:

```
ERROR: Syntax Error while loading YAML script, <...>/oh-my-zsh/tasks/main.yml
Note: The error may actually appear before this position: line 22, column 17

    sudo: true
    sudo_user: {{ ohmyzsh.user }}
                ^
We could be wrong, but this one looks like it might be an issue with
missing quotes.  Always quote template expression brackets when they
start a value. For instance:

    with_items:
      - {{ foo }}

Should be written as:

    with_items:
      - "{{ foo }}"
```
