### PR TITLE
Make git clone on behalf of ohmyzsh_user

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,8 @@
   notify: clean yum cache
 
 - git: repo=https://github.com/robbyrussell/oh-my-zsh.git dest=~/.oh-my-zsh accept_hostkey=true update=no
+  become: true
+  become_user: "{{ ohmyzsh_user }}"
 
 - template: src=.zshrc.j2 dest=~/.zshrc backup=yes
   become: true


### PR DESCRIPTION
If I use ohmyzsh_plbk role from a playbook running with a "become_user: root", git clone is done on /root/.oh-my-zsh path.
